### PR TITLE
Give more information on validate_signature errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 	rm -fr venv lambda.zip ami-built-lambda.zip
 
 virtualenv:
-	virtualenv --no-site-packages venv
+	virtualenv venv --python=python2.7
 	venv/bin/pip install -r requirements.pip
 
 zip: clean virtualenv


### PR DESCRIPTION
This PR brings more feature to the validate_signature script:
 - Give more information to understand the error
 - Don't fail on the first signature error so that we can monitor all the collection and not stop at the first one.