### PR TITLE
Skip newly created collections (fixes #31)

### DIFF
--- a/aws_lambda.py
+++ b/aws_lambda.py
@@ -59,7 +59,7 @@ def validate_signature(event, context):
         messages.append(message)
 
         # 1. Grab collection information
-        dest_col = client.get_collection()
+        dest_col = client.get_collection()['data']
 
         # 2. Grab records
         records = client.get_records(_sort='-last_modified')
@@ -73,7 +73,7 @@ def validate_signature(event, context):
 
         # 5. Grab the signature
         try:
-            signature = dest_col['data']['signature']
+            signature = dest_col['signature']
         except KeyError:
             # Destination has no signature attribute.
             # Be smart and check if it was just configured.


### PR DESCRIPTION
Fixes #31 

This idea here is to provide a fix that:

- is orthogonal to #33 
- could be backported to version 3.2.X
- would be a safety check until https://github.com/Kinto/kinto-signer/issues/226 is implemented on the server


Here is the output with current prod:

```

Looking at /buckets/monitor/collections/changes: 
Looking at /buckets/blocklists/collections/addons: Signature OK
Looking at /buckets/blocklists-preview/collections/addons: Signature OK
Looking at /buckets/blocklists/collections/plugins: Signature OK
Looking at /buckets/blocklists-preview/collections/plugins: Signature OK
Looking at /buckets/blocklists/collections/certificates: Signature OK
Looking at /buckets/blocklists-preview/collections/certificates: Signature OK
Looking at /buckets/security-state-preview/collections/intermediates: SKIP
Looking at /buckets/security-state/collections/intermediates: SKIP
Looking at /buckets/blocklists-preview/collections/gfx: Signature KO.
 - Signature: `[...]`
 - Computed hash: `z31+FbQ4Y6QYCcIrIZ7FxSasNIogu4mID1RcMQsX5S+THvlfUTXAw07Rs5ClOYdv`
 - Collection timestamp: `1518124248842`
 - Serialized content: `[...]`
Looking at /buckets/blocklists/collections/qa: Signature KO.
 - Signature: `[...]`
 - Computed hash: `zgG/RtdEgd6nIFtRBkiGpv4bcPyjjrQBGC5kj+gwX2UYMFoBb4C6cmZu5/x2LunY`
 - Collection timestamp: `1518124248754`
 - Serialized content: `[...]`
Looking at /buckets/fingerprinting-defenses-preview/collections/fonts: Signature OK
Looking at /buckets/focus-preview/collections/experiments: SKIP
Looking at /buckets/pinning-preview/collections/pins: SKIP
Looking at /buckets/focus/collections/experiments: SKIP
Looking at /buckets/fingerprinting-defenses/collections/fonts: SKIP
Looking at /buckets/pinning/collections/pins: Signature KO.
 - Signature: `[...]`
 - Computed hash: `Vga6Sr1K5yEkIO5b8onG0GF8dt0o0R1i4iAjJC250co9kr8F0h5KbuoCIfwZa3HT`
 - Collection timestamp: `1485794868067`
 - Serialized content: `[...]`
Looking at /buckets/blocklists/collections/gfx: Signature OK
```
