### PR TITLE
Improve error messages (fixes #35)

### DIFF
--- a/aws_lambda.py
+++ b/aws_lambda.py
@@ -34,20 +34,19 @@ def validate_signature(event, context):
     client = Client(server_url=server_url,
                     bucket=bucket,
                     collection=collection)
-    print('Looking at %s: ' % client.get_endpoint('collection'))
+    print('Read collection list from {}'.format(client.get_endpoint('collection')))
 
     collections = client.get_records()
 
-    exception = None
-    messages = []
+    error_messages = []
 
-    for collection in collections:
+    for i, collection in enumerate(collections):
         client = Client(server_url=server_url,
                         bucket=collection['bucket'],
                         collection=collection['collection'])
-        message = 'Looking at %s: ' % client.get_endpoint('collection')
-        print(message, end='')
-        messages.append(message)
+
+        endpoint = client.get_endpoint('collection')
+        message = "{:02d}/{:02d} {}:  ".format(i + 1, len(collections), endpoint)
 
         # 1. Grab collection information
         dest_col = client.get_collection()['data']
@@ -72,9 +71,8 @@ def validate_signature(event, context):
             with_tombstones = client.get_records(_since=1)
             if len(with_tombstones) == 0:
                 # It never contained records. Let's assume it is newly configured.
-                message = 'SKIP'
+                message += 'SKIP'
                 print(message)
-                messages.append(message)
                 continue
             # Some records and empty signature? It will fail below.
             signature = {}
@@ -88,24 +86,26 @@ def validate_signature(event, context):
             # 7. Verify the signature matches the hash
             signer = ECDSASigner(public_key=f.name)
             signer.verify(serialized, signature)
-            message = 'Signature OK'
+            message += 'OK'
             print(message)
-            messages.append(message)
         except Exception as e:
-            exception = e
-            message = ('Signature KO.',
-                       ' - Signature: `{}`'.format(signature),
-                       ' - Computed hash: `{}`'.format(computed_hash),
-                       ' - Collection timestamp: `{}`'.format(timestamp),
-                       ' - Serialized content: `{}`'.format(serialized))
-            print("\n".join(message))
-            messages.extend(message)
+            message += '⚠ BAD Signature ⚠'
+            print(message)
+
+            # Gather details for the global exception that will be raised.
+            error_message = (
+                'Signature verification failed on {endpoint}\n'
+                ' - Signature: `{signature}`\n'
+                ' - Collection timestamp: `{timestamp}`\n'
+            ).format(**locals())
+            error_messages.append(error_message)
+
         finally:
             os.unlink(f.name)
 
     # Make the lambda to fail in case an exception occured
-    if exception is not None:
-        raise ValidationError("{}:\n{}".format(exception, "\n".join(messages)))
+    if len(error_messages) > 0:
+        raise ValidationError("\n\n".join(error_messages))
 
 
 def validate_changes_collection(event, context):


### PR DESCRIPTION
Fixes #35 

A few changes:

- the `print()` with `end=''` had no effect in lambda logs, which was not helping readibility (see https://github.com/mozilla-services/amo2kinto/issues/83)
- we now print the whole list, and print error details at the end (less confusing)
- since the server serialized content is not accesible anyway, no need to print it out, it brought a lot of noise.

This is how it looks like now. I find it a lot clearer

```
$ SERVER=https://firefox.settings.services.mozilla.com/v1/ python aws_lambda.py validate_signature

Read collection list from /buckets/monitor/collections/changes
01/17 /buckets/blocklists/collections/addons:  OK
02/17 /buckets/blocklists-preview/collections/addons:  OK
03/17 /buckets/blocklists/collections/plugins:  OK
04/17 /buckets/blocklists-preview/collections/plugins:  OK
05/17 /buckets/blocklists/collections/certificates:  OK
06/17 /buckets/blocklists-preview/collections/certificates:  OK
07/17 /buckets/security-state-preview/collections/intermediates:  SKIP
08/17 /buckets/security-state/collections/intermediates:  SKIP
09/17 /buckets/blocklists-preview/collections/gfx:  ⚠ BAD Signature ⚠
10/17 /buckets/blocklists/collections/qa:  ⚠ BAD Signature ⚠
11/17 /buckets/fingerprinting-defenses/collections/fonts:  OK
12/17 /buckets/fingerprinting-defenses-preview/collections/fonts:  OK
13/17 /buckets/focus-preview/collections/experiments:  SKIP
14/17 /buckets/pinning-preview/collections/pins:  SKIP
15/17 /buckets/focus/collections/experiments:  SKIP
16/17 /buckets/pinning/collections/pins:  ⚠ BAD Signature ⚠
17/17 /buckets/blocklists/collections/gfx:  OK
Traceback (most recent call last):
  File "aws_lambda.py", line 336, in <module>
    function(event, context)
  File "aws_lambda.py", line 108, in validate_signature
    raise ValidationError("\n\n".join(error_messages))
__main__.ValidationError: Signature verification failed on /buckets/blocklists-preview/collections/gfx
 - Signature: `{'ref': '2zk4okyqk3buu2dslu5khcs31s', 'x5u': 'https://content-signature.cdn.mozilla.net/chains/onecrl.content-signature.mozilla.org-20180209.prod.chain', 'mode': 'p384ecdsa', 'type': 'contentsignature', 'signature': 'CRSMiAZ5_iDcvCqbGzpTpx1H84WF8JMRd8zjzjfnmUNBhoIqnEGNFOIKQuVD4NIUzp8XhDl3h2lb9MkbiBHPdM9B297Yc5iNzHmhngEzAXqetv7lJuNp9_ZJDasaATpY', 'signer_id': 'onecrl_key', 'public_key': 'MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvLNlz6U2mREMeuWotT+lz/CDQ8A4IDcWYmGTuI+29126q1ItA3Hh3G6tMGxkEOw52J63ShS1zMsl+3n06cyQet/oNjViqggV8cHR2LzJA2rcgGdFjYtvgYemlMqDIIuH'}`
 - Collection timestamp: `1518124248842`


Signature verification failed on /buckets/blocklists/collections/qa
 - Signature: `{'ref': '3lwpae2waund720ybwt9110v91', 'x5u': 'https://content-signature.cdn.mozilla.net/chains/onecrl.content-signature.mozilla.org-20160610.prod.chain', 'signature': '05U9rcJEsSF9z9DeaDkGlgUIyHJX4Sgv8eycNrxhdb1Z10dwwfDnzldqrH98xTRjthqGIhR2E26xh7KzEAzek8veAZHZlYvpLOnX7tSN4b7Wt-S8AwaMMwS_snjRAL3a', 'public_key': 'MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEIfwOO0lZ7+RHQ4vr3foRR4DMtaTRX9cr3wpirWrIAHa5MS9/OVwZHk1nLEXLu5+c/3kjy37Xg/pzQ9gDTfbLIvjRZ4v9dLp9NOCX6o2NTPdEiirOGuWtAI/QXuXl66P2', 'hash_algorithm': 'sha384', 'content-signature': 'x5u="https://content-signature.cdn.mozilla.net/chains/onecrl.content-signature.mozilla.org-20160610.prod.chain";p384ecdsa=05U9rcJEsSF9z9DeaDkGlgUIyHJX4Sgv8eycNrxhdb1Z10dwwfDnzldqrH98xTRjthqGIhR2E26xh7KzEAzek8veAZHZlYvpLOnX7tSN4b7Wt-S8AwaMMwS_snjRAL3a', 'signature_encoding': 'rs_base64url'}`
 - Collection timestamp: `1518124248754`


Signature verification failed on /buckets/pinning/collections/pins
 - Signature: `{'ref': '1iq3xa811kr953u9nlnntcv853', 'x5u': 'https://content-signature.cdn.mozilla.net/chains/pinning-preload.content-signature.mozilla.org-20180209.prod.chain', 'mode': 'p384ecdsa', 'type': 'contentsignature', 'signature': 'uHyUSDKlGRILiNUPcSQzMPL1KKFe_6cZRVM-CH8wYjMrng-ClakDkXZJtm-49zdwo5UncZIZPKi-cbH4MA__9bNqxQfAYt_ZC3eXpM7VOfS4oWb19m_pUoBf0TA9Uzlz', 'signer_id': 'pinningpreload_key', 'public_key': 'MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5R4xGq5XOLixwe9q1BVvRMuPhvNl1cP4bGsmD6yUtv3uboBzFGVCRhntmNGVNVuky4YFs+qAGRATHc7Rxya2pAbkrVAzXUi3nvEQT4sNJxhOxcMuX+XCjUmJUQecmp83'}`
 - Collection timestamp: `1485794868067`


```