### PR TITLE
Use x5u certificate to validate the signature (fixes #18)

### DIFF
--- a/aws_lambda.py
+++ b/aws_lambda.py
@@ -1,10 +1,5 @@
 from __future__ import print_function
 import base64
-import cryptography
-import cryptography.x509
-from cryptography.hazmat.backends import default_backend as crypto_default_backend
-from cryptography.hazmat.primitives import serialization as crypto_serialization
-from cryptography.x509.oid import NameOID
 import hashlib
 import json
 import operator
@@ -18,9 +13,14 @@ from tempfile import mkdtemp
 
 import boto3
 import boto3.session
+import cryptography
+import cryptography.x509
 import ecdsa
 from amo2kinto.generator import main as generator_main
 from botocore.exceptions import ClientError
+from cryptography.hazmat.backends import default_backend as crypto_default_backend
+from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.x509.oid import NameOID
 from kinto_http import Client
 
 

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,4 +1,7 @@
-kinto-http
 amo2kinto
+botocore
 boto3
+cryptography
 ecdsa
+kinto-http
+requests


### PR DESCRIPTION
Fixes #18

It just doesn't work... `InvalidSignature`

@jvehent by chance, would you have a code sample in python to validate the certificate chain? I found this https://gist.github.com/jvehent/d60cde341f9ebb66843e452200c148be but didn't know what else I could do 
